### PR TITLE
add Project.toml and runtests.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,17 @@
+name = "Pluto2Jupyter"
+uuid = "e639118c-ac9c-11ed-afa1-0242ac120002"
+version = "0.1.0"
+
+[deps]
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[compat]
+julia = "1.6"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,2 @@
+test1.jl
+test2.ipynb

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,5 @@
+using Test
+using Pluto2Jupyter
+
+nb2jl(joinpath(@__DIR__, "test1.ipynb"))
+jl2nb(joinpath(@__DIR__, "test2.jl"))


### PR DESCRIPTION
This package is quite useful and it would
be nice to have it registered for use.
Adding a Project.toml allows it to be integrated
into other project/workflows. The simple runtests.jl exercises the functionality.